### PR TITLE
Output optimal h for kernel smoothing

### DIFF
--- a/R/estimate_npmetric_erf.R
+++ b/R/estimate_npmetric_erf.R
@@ -106,6 +106,8 @@ estimate_npmetric_erf<-function(matched_Y,
   result$params$matched_w <- matched_w
   result$params$bw_seq <- bw_seq
   result$params$w_vals <- w_vals
+  result$risk_val <- risk_val
+  result$h_opt <- h_opt
   result$erf <- erf
   result$fcall <- fcall
 


### PR DESCRIPTION
I added two lines of code to output optimal h and estimated risk function values after implementing Kernel smoothing in estimate_npmetric_erf.R